### PR TITLE
Four more items, all for the CSS part.

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@ K###########,  KW   ,#####    #G                                          ##    
                   <li>
                     <a href="http://www.w3schools.com/css3/css3_fonts.asp" rel="nofollow" class="w3s-link">www.w3schools.com/css3/css3_fonts.asp</a>.
                     <p>
-                      Oh and there I thought Microsoft invented the <code>@font-face</code> at-rule! I'm also wondering about this <code>url</code> descriptor for usage in at-rules.
+                      Oh and there I thought Microsoft invented the <code>@font-face</code> at-rule! It's not entirely new in CSS3 either, as it was previously defined in CSS2 (but not in 2.1). There's no such thing as the <code>url</code> descriptor for font-face rules either.
                     </p>
                   </li>
                 </ul>


### PR DESCRIPTION
Added items for (CSS):
- A weird "CSS Don't" page which briefly talks about not using HTC descriptors, then gives large (useful!) examples which lots of people will copy-and-paste.
- Four missing properties for 2D Transforms, while two other (skewX/skewY) were listed.
- No such thing as ::selection in CSS3.
- @font-face is not supported by Internet Explorer, you know, that thing they have since IE5.5 is fake. It's a lie.
