### PR TITLE
Add note about Personal Blocklist extension for Google Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -1476,7 +1476,7 @@ VALUES
 
 
     <footer>
-      <p>In absolutely <strong>NO WAY</strong> is this site associated with the W3C. Or the W3Schools for that matter, but you probably knew that. ;)</p>
+      <p>In absolutely <strong>NO WAY</strong> is this site associated with the W3C or w3schools for that matter, but you probably knew that. ;)</p>
     </footer>
   </div> <!--! end of #container -->
 


### PR DESCRIPTION
Just thought a quick note about the the Personal Blocklist extension for Google Chrome may be relavent/helpful, following on from the point about filtering w3schools from search results.

It certainly helps remove garbage sites from results pages and I also like to think of it as kind of a symbolic petition for Google to devalue them (although I may be dreaming about that).
