### PR TITLE
Added <abbr> to "OSS" and fixed a typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
 
           <section class="content"><h2 id="build-one-yourselves">&ldquo;Build One Yourself&rdquo;</h2>
           <p>
-            An oft-repeated mantra in OSS (and a critique we've already received) is that you shouldn't criticise something unless you're willing to put your money where your mouth is and build something better.  It's an admirable ethos, but not really applicable here.</p>
+            An oft-repeated mantra in <abbr title="Open-source Software">OSS</abbr> (and a critique we've already received) is that you shouldn't criticise something unless you're willing to put your money where your mouth is and build something better.  It's an admirable ethos, but not really applicable here.</p>
             <p>W3Schools has put a lot of effort into positioning itself at the top of search results and, despite our efforts (such as the
             <a href="http://promotejs.com/">PromoteJS</a> initiative), appears to be there to stay. Other, better resources already exist, but
             none of them are capable of overcoming the inertia that W3Schools has built up over the years.</p>
@@ -331,7 +331,7 @@
                     <p>
                       Extensions are not necessary at all and if they are present they don't have to be
                       <code>.htm</code> or <code>.html</code>. The key thing is that HTML files are served with
-                      the corrent content-type e.g. <code>text/html</code>.  (many web servers have some built in
+                      the correct content-type e.g. <code>text/html</code>.  (many web servers have some built in
                       or preconfigured knowledge that <code>.htm</code> and <code>.html</code> should be served
                       with the <code>text/html</code> content-type)
                     </p>


### PR DESCRIPTION
The site uses the <code>&lt;abbr&gt;</code> element for other stuff, but not for the reference to "OSS", so I fixed that. Also corrected a spelling error, ironically on the word "correct". :)
