### PR TITLE
Updated links, deleted solved entries, added to reasoning, prioritized some problems.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -98,7 +98,8 @@ header h2:before {
 
 
 .incorrect:before,
-.cert:before {
+.cert:before,
+.nocommunity:before {
   display: block;
   content: "";
   position: absolute;
@@ -107,7 +108,7 @@ header h2:before {
   border-top: 1px dotted;
 }
 
-.incorrect, .cert, .noaffiliation, .sucks li  { list-style: none; }
+.incorrect, .cert, .noaffiliation, .nocommunity, .sucks li  { list-style: none; }
 
 section nav a { display: inline-block; margin: 0 1em; }
 section nav a:first-child { margin-left: 0; }
@@ -248,10 +249,10 @@ p:last-of-type, li:last-of-type { margin-bottom: 0; }
 
 .intro p { margin-bottom: 1.5em; }
 
-.incorrect:before,
+.nocommunity:before, .incorrect:before,
 .cert:before { margin-top: -1.5em; }
 
-.incorrect, .cert, .noaffiliation {
+.incorrect, .cert, .nocommunity, .noaffiliation {
   margin: 0;
   min-height: 3em;
   padding: 1.5em 0;

--- a/index.html
+++ b/index.html
@@ -116,6 +116,12 @@
               ANSI/ISO accredited certifications, W3Schools has no support from governing standards bodies.
             </li>
 
+            <li class='nocommunity'>
+              W3Schools.com is slow to update material on its site, and provides no mechanism to allow the community to contribute updates or corrections.  
+              In a world where the html5 spec&#151;itself built by a community effort&#151;is growing and gaining speed, outdated and unchanging examples with
+              high visibility are a hinderance to the web.
+            </li>
+
             <li class="incorrect">
               W3Schools frequently publishes inaccurate or misleading content. We have collected several examples
               illustrating this problem below.
@@ -150,7 +156,8 @@
           <ol>
             <li>
               <strong>W3Schools</strong> should consider <abbr title="make the site a wiki. Or.. put it all in public source control, like on Github.">wikifying</abbr> their content so the community could self-correct and keep the information
-              up-to-date. Today, they do not even allow you to submit corrections on a page. They should.
+              up-to-date. Previously, they did not even have a mechanism for submitting corrections.  
+              They now have a tiny "REPORT ERROR" link in their footer.  We should use it liberally and see how responsive they are to inaccuracies.
             </li>
 
 
@@ -224,7 +231,7 @@
                     <a href="http://www.w3schools.com" rel="nofollow" class="w3s-link">http://www.w3schools.com/</a>.
                     <p>
                       The markup of the W3Schools site itself is awful and does not conform to best practices: <del>table in
-                      table in table in table</del> <ins>div in div in div in div</ins>, with <strong>lots</strong> of inline styles.
+                      table in table in table</del> <ins>now div in div in div in div</ins>, with <strong>lots</strong> of inline styles.
                       The content of the site's pages talk about html5, but it has not been implemented on their own site.
                     </p>
                   </li>
@@ -351,7 +358,7 @@ Last name: &lt;input type="text" name="lastname" />
                     <a href="http://www.w3schools.com/html/html_colornames.asp" rel="nofollow" class="w3s-link">www.w3schools.com/html/html_colornames.asp</a>,
                     <a href="http://www.w3schools.com/html/html_colorvalues.asp" rel="nofollow" class="w3s-link">www.w3schools.com/html/html_colorvalues.asp</a>
                     <p>
-                      This is all CSS stuff. It should not be listed in the HTML section. Additionally, the Color Names page lies: not all browsers support the 130 SVG colors.
+                      This is all CSS stuff. It should not be listed in the HTML section. Additionally, the Color Names page is misleading: not all browsers support the 130 SVG colors.
                     </p>
                   </li>
 


### PR DESCRIPTION
My original intention was just to add an entry about the circular definition of article as "defines an article" and section as "defines a section", but when I got in there I found lots of wild & wooly things, marked various problems as <del>solved</del> and tried to prioritize some of the more systemic issues to the top and <del>solved</del> issues to the bottom.

One quite interesting thing that I found is that the w3schools site now has a "REPORT ERROR" link in very tiny text in their footer.  I suggest we begin to use it liberally to report many of the various problems found on the w3fools site, and see if they do anything about it.
