### PR TITLE
Fix search query: filter out w3schools by url

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
             <ol>
               <li>You can filter out w3schools from your searches by:
                <ul>
-                <li>Adding <code>-w3schools</code> to your search query</li>
+                <li>Adding <code>-inurl:w3schools.com</code> to your search query</li>
                 <li>Use <a href="https://chrome.google.com/webstore/detail/w3schools-hider/igiahejkpbnbnekdaefddmdceocmjpll">W3Schools Hider Extension for Chrome</a> or the <a href="https://addons.mozilla.org/en-US/firefox/addon/w3schools-hider/">W3Schools Hider add-on for FireFox</a> to automatically remove w3schools results from Google</li>
                 <li>To get results from the Mozilla Dev Network, just prepend <code>mdn</code> to your search query</li>
                </ul>


### PR DESCRIPTION
To filter out w3schools adequately, "-inurl:w3schools.com" should be used instead of simply "-w3schools". Likely you meant to block the url, not all websites referring to w3school in their content. Like w3fools.com...

Example:
- **query**: w3fools -w3schools
  **result**: w3fools.com is filtered out (not what you want)
- **query**: w3fools -inurl:w3schools.com
  **result**: w3fools.com is the first result

_Note: not tested against all available search engines, obviously. It works for Google, Yahoo and Bing, for starters._
